### PR TITLE
Fix: Fire correct exception type out of the library

### DIFF
--- a/KeePassXC-API/CommunicationHelper.cs
+++ b/KeePassXC-API/CommunicationHelper.cs
@@ -38,6 +38,11 @@ namespace KeePassXC_API
                 //start the key exchange
                 ExchangeKeys().Wait();
             }
+            catch (AggregateException e)
+            {
+                ((IDisposable)this).Dispose();
+                throw e.InnerException;
+            }
             catch
             {
                 ((IDisposable)this).Dispose();


### PR DESCRIPTION
I found a small issue in my code. The exception type which was thrown to the client was the wrong type because the throw happens in a wait statement which wrap up the original in a AggregationException.