### PR TITLE
Convert to .NET Standard 2.0 and fix writing of connection information

### DIFF
--- a/KeePassXC-API/Actions.cs
+++ b/KeePassXC-API/Actions.cs
@@ -9,20 +9,20 @@ namespace KeePassXC_API
     {
         public string Type { get; private set; }
 
-        public static readonly Actions SetLogin = new("set-login");
-        public static readonly Actions GetLogins = new("get-logins");
-        public static readonly Actions GeneratePassword = new("generate-password");
-        public static readonly Actions Associate = new("associate");
-        public static readonly Actions TestAssociate = new("test-associate");
-        public static readonly Actions GetDatabaseHash = new("get-databasehash");
-        public static readonly Actions ExchangePublicKeys = new("change-public-keys");
-        public static readonly Actions LockDatabase = new("lock-database");
-        public static readonly Actions DatabaseLocked = new("database-locked");
-        public static readonly Actions DatabaseUnlocked = new("database-unlocked");
-        public static readonly Actions GetDatabaseGroups = new("get-database-groups");
-        public static readonly Actions CreateNewGroup = new("create-new-group");
-        public static readonly Actions GetTOTP = new("get-totp");
-        public static readonly Actions LoadKeyring = new("load_keyring");
+        public static readonly Actions SetLogin = new Actions("set-login");
+        public static readonly Actions GetLogins = new Actions("get-logins");
+        public static readonly Actions GeneratePassword = new Actions("generate-password");
+        public static readonly Actions Associate = new Actions("associate");
+        public static readonly Actions TestAssociate = new Actions("test-associate");
+        public static readonly Actions GetDatabaseHash = new Actions("get-databasehash");
+        public static readonly Actions ExchangePublicKeys = new Actions("change-public-keys");
+        public static readonly Actions LockDatabase = new Actions("lock-database");
+        public static readonly Actions DatabaseLocked = new Actions("database-locked");
+        public static readonly Actions DatabaseUnlocked = new Actions("database-unlocked");
+        public static readonly Actions GetDatabaseGroups = new Actions("get-database-groups");
+        public static readonly Actions CreateNewGroup = new Actions("create-new-group");
+        public static readonly Actions GetTOTP = new Actions("get-totp");
+        public static readonly Actions LoadKeyring = new Actions("load_keyring");
 
         private Actions(string type)
         {

--- a/KeePassXC-API/CommunicationHelper.cs
+++ b/KeePassXC-API/CommunicationHelper.cs
@@ -16,7 +16,7 @@ namespace KeePassXC_API
         /// <summary>
         /// clientID field send with every message, is unique to each session
         /// </summary>
-        private string clientId { get; init; }
+        private string clientId { get; }
         private byte[] clientPublicKey { get; } = new byte[32];
         private byte[] clientPrivateKey { get; } = new byte[32];
         private BigInteger nonce { get; set; }
@@ -29,14 +29,16 @@ namespace KeePassXC_API
             try
             {
                 //Generate Crypto stuff
-                using RandomNumberGenerator rng = RandomNumberGenerator.Create();
-                clientId = rng.GetBytes(24).ToBase64();
-                nonce = new BigInteger(rng.GetBytes(24));
-                //generate public and private key
-                Curve25519XSalsa20Poly1305.KeyPair(clientPrivateKey, clientPublicKey);
+                using (RandomNumberGenerator rng = RandomNumberGenerator.Create())
+                {
+                    clientId = rng.GetBytes(24).ToBase64();
+                    nonce = new BigInteger(rng.GetBytes(24));
+                    //generate public and private key
+                    Curve25519XSalsa20Poly1305.KeyPair(clientPrivateKey, clientPublicKey);
 
-                //start the key exchange
-                ExchangeKeys().Wait();
+                    //start the key exchange
+                    ExchangeKeys().Wait();
+                }
             }
             catch (AggregateException e)
             {
@@ -167,7 +169,7 @@ namespace KeePassXC_API
         /// <summary>
         /// Waits for a message and checks it for errors and given type.
         /// </summary>
-        public async Task<T> ReadMessage<T>(Actions? type, TimeSpan? timeOut = null, bool waitForUnlook = false) where T : ResponseMessage
+        public async Task<T> ReadMessage<T>(Actions type, TimeSpan? timeOut = null, bool waitForUnlook = false) where T : ResponseMessage
         {
             while (true)
             {

--- a/KeePassXC-API/Exceptions.cs
+++ b/KeePassXC-API/Exceptions.cs
@@ -5,7 +5,7 @@ namespace KeePassXC_API
 {
     public class KeePassXCException : Exception
     {
-        public static Dictionary<int, KeePassXCException> Exceptions = new()
+        public static Dictionary<int, KeePassXCException> Exceptions = new Dictionary<int, KeePassXCException>()
         {
             { 0 , new KXCUnknowException() },
             { 1 , new KXCDatabaseNotOpenException() },

--- a/KeePassXC-API/IDatabaseInformationSaver.cs
+++ b/KeePassXC-API/IDatabaseInformationSaver.cs
@@ -6,8 +6,8 @@ namespace KeePassXC_API
 {
     public interface IDatabaseInformationSaver
     {
-        public Task<DatabaseInformation[]> LoadAsync();
-        public Task SaveAsync(DatabaseInformation[] info);
+        Task<DatabaseInformation[]> LoadAsync();
+        Task SaveAsync(DatabaseInformation[] info);
     }
 
     public class DefaultDatabaseInformationSaver : IDatabaseInformationSaver
@@ -18,8 +18,14 @@ namespace KeePassXC_API
         {
             try
             {
-                using FileStream fs = new FileStream(Filename, FileMode.Open, FileAccess.Read);
-                return await JsonSerializer.DeserializeAsync<DatabaseInformation[]>(fs);
+                using (FileStream fs = new FileStream(Path.Combine(System.AppDomain.CurrentDomain.BaseDirectory, Filename), FileMode.Open, FileAccess.Read))
+                {
+                    return await JsonSerializer.DeserializeAsync<DatabaseInformation[]>(fs);
+                }
+            }
+            catch (JsonException)
+            {
+                return new DatabaseInformation[0];
             }
             catch (FileNotFoundException)
             {
@@ -29,8 +35,10 @@ namespace KeePassXC_API
 
         public async Task SaveAsync(DatabaseInformation[] info)
         {
-            using FileStream fs = new FileStream(Filename, FileMode.OpenOrCreate, FileAccess.Write);
-            await JsonSerializer.SerializeAsync(fs, info);
+            using (FileStream fs = new FileStream(Path.Combine(System.AppDomain.CurrentDomain.BaseDirectory, Filename), FileMode.Create, FileAccess.Write))
+            {
+                await JsonSerializer.SerializeAsync(fs, info);
+            }
         }
     }
 }

--- a/KeePassXC-API/KeePassXC-API.csproj
+++ b/KeePassXC-API/KeePassXC-API.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>KeePassXC_API</RootNamespace>
     <Authors>TheHllm</Authors>
     <Product>-</Product>
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="NaCl.Net" Version="0.1.13" />
-    <PackageReference Include="NativeMessaging.Client" Version="1.0.2" />
+    <PackageReference Include="NativeMessaging.Client" Version="1.0.4" />
   </ItemGroup>
 
 </Project>

--- a/KeePassXC-API/KeepassXCApi.cs
+++ b/KeePassXC-API/KeepassXCApi.cs
@@ -230,7 +230,7 @@ namespace KeePassXC_API
 				{
 					await communicatior.SendEncrypted(new BasicMessage(Actions.GetDatabaseHash), true);
 					ResponseMessage msg = await communicatior.ReadMessage<ResponseMessage>(null, waitForUnlook: true);
-					if (msg.Action != Actions.DatabaseUnlocked && msg.Action != Actions.GetDatabaseHash)
+					if (msg.Action != Actions.DatabaseUnlocked && msg.Action != Actions.DatabaseLocked && msg.Action != Actions.GetDatabaseHash)
 						throw new KXCWrongMessageException();
 					if (msg.Action == Actions.GetDatabaseHash)
 						break;


### PR DESCRIPTION
Converted to .NET Standard 2.0 and downgrades C# version 7.3 which is the default language version for .NET Standard.
In addition I made a bugfix in the storing of connection information. Previously the file was not truncated which could cause problems and I improved the error handling in case the the reading of the file was not possible. Another fix is, that I use the application base directory for storing the info file instead of using the current directory which could be changed depending on the state of the application which uses the library. 
I tested all workflows again and anything seems to work fine now. Thank you for providing this library!

Related issue https://github.com/TheHllm/KeePassXC-API/issues/5 can be closed after merge